### PR TITLE
Fix typo in data-science-i course name

### DIFF
--- a/specializations/data-science-i.md
+++ b/specializations/data-science-i.md
@@ -10,7 +10,7 @@ Expand beyond Computer Science into Statistics, Probability and Data Science
 | [M001: MongoDB Basics](https://university.mongodb.com/courses/catalog)                                                                                                |            |
 | [Applied Data Science with Python](https://cognitiveclass.ai/learn/data-science-with-python/)                                                                         |            |
 | [Deep Learning](https://cognitiveclass.ai/learn/deep-learning/)                                                                                                       |            |
-| [M200P](https://university.mongodb.com/courses/catalog)                                                                                                               |            |
+| [M220P](https://university.mongodb.com/courses/catalog)                                                                                                               |            |
 | [Introduction to Probability and Statistics](https://ocw.mit.edu/courses/mathematics/18-05-introduction-to-probability-and-statistics-spring-2014/index.htm) (more rigorous) or [Khan Academy Probability and Statistics](https://www.khanacademy.org/math/statistics-probability) (a more gentle introduction)         |            |
 | **Reading**                                                                                                                                                           | **Status** | **Evidence** |
 | [Think Python](http://greenteapress.com/thinkpython2/thinkpython2.pdf)                                                                                                |            |


### PR DESCRIPTION
I believe there is a typo in the course title M200P as such course does not exist in the linked catalog. Browsing through the catalog, however, there is a similar title M220P, which seems to be relevant.