### PR TITLE
Update App Academy Open curriculum

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ Complete the [App Academy Open](https://open.appacademy.io/) free online Fullsta
 | Full Stack Online - React                                                                                                                                             |            |              |
 | Full Stack Online - Full Stack Project                                                                                                                                |            |              |
 | Full Stack Online - Job Search                                                                                                                                        |            |              |
+| Full Stack Online - Docker |
+|            |              |
+| Full Stack Online - GraphQl |
+|            |              |
 | **Capstone**                                                                                                                                                          | **Status** | **Evidence** |
 | Create a website highlighting what you learned and built during this tier. Use this as an opportunity to create a portfolio of your projects, notes, blog posts, etc. |            |
 


### PR DESCRIPTION
A few days ago App Academy Open has extended their curriculum by adding Docker and GraphQL courses. Assumed to be done during 7 days. It might be some legendary 'missing' materials mentioned in issues. Thought you want to know.