### PR TITLE
Update the_odin_project_ruby.md

### DIFF
--- a/specializations/the_odin_project_ruby.md
+++ b/specializations/the_odin_project_ruby.md
@@ -4,7 +4,7 @@ Complete [The Odin Project - Full Stack Ruby on Rails](https://www.theodinprojec
 
 | Courses                                                                                                                                                                         |   Status   |   Evidence   |
 | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :--------: | :----------: |
-| Web Development 101                                                                                                                                                             |            |              |
+| Fundamentals                                                                                                                                                             |            |              |
 | Ruby Programming                                                                                                                                                                |            |              |
 | Databases                                                                                                                                                                       |            |              |
 | Ruby on Rails                                                                                                                                                                   |            |              |


### PR DESCRIPTION
Odin Project has rebranded their Web Development 101 course to 'Fundamentals'. It is actually an entirely separate path now but that I don't think making that distinction here is necessary.